### PR TITLE
Allow deb users to set the heap size

### DIFF
--- a/attributes/proxy.rb
+++ b/attributes/proxy.rb
@@ -11,6 +11,7 @@ users = Chef::DataBagItem.load('elasticsearch', 'users')[node.chef_environment][
 #
 # It's possible to define the credentials directly in your node configuration, if your wish.
 #
+default.elasticsearch[:nginx][:server_name]    = "elasticsearch"
 default.elasticsearch[:nginx][:port]           = "8080"
 default.elasticsearch[:nginx][:dir]            = ( node.nginx[:dir]     rescue '/etc/nginx'     )
 default.elasticsearch[:nginx][:user]           = ( node.nginx[:user]    rescue 'nginx'          )

--- a/recipes/deb.rb
+++ b/recipes/deb.rb
@@ -11,3 +11,12 @@ end
 dpkg_package "#{Chef::Config[:file_cache_path]}/#{filename}" do
   action :install
 end
+
+ruby_block "Set heap size in /etc/default/elasticsearch" do
+  block do
+    fe = Chef::Util::FileEdit.new("/etc/default/elasticsearch")
+    fe.insert_line_if_no_match(/ES_HEAP_SIZE=/, "ES_HEAP_SIZE=#{node.elasticsearch[:allocated_memory]}")
+    fe.search_file_replace_line(/ES_HEAP_SIZE=/, "ES_HEAP_SIZE=#{node.elasticsearch[:allocated_memory]}") # if the value has changed but the line exists in the file
+    fe.write_file
+  end
+end

--- a/templates/default/elasticsearch_proxy.conf.erb
+++ b/templates/default/elasticsearch_proxy.conf.erb
@@ -1,6 +1,6 @@
 server {
   listen   <%= node.elasticsearch[:nginx][:port] %>;
-  server_name  elasticsearch;
+  server_name  <%= node.elasticsearch[:nginx][:server_name] %>;
   client_max_body_size <%= node.elasticsearch[:nginx][:client_max_body_size] %>;
 
   error_log   <%= node.elasticsearch[:nginx][:log_dir] %>/elasticsearch-errors.log;
@@ -53,4 +53,16 @@ server {
   }
 <% end %>
 
+<% if node.elasticsearch[:nginx][:ssl][:cert_file] && node.elasticsearch[:nginx][:ssl][:key_file] %>
+  ssl on;
+  ssl_certificate <%= node.elasticsearch[:nginx][:ssl][:cert_file] %>;
+  ssl_certificate_key <%= node.elasticsearch[:nginx][:ssl][:key_file] %>;
+  
+  server_tokens off;
+  ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
+  ssl_prefer_server_ciphers on;
+  ssl_session_timeout 10m;
+  ssl_ciphers TLS_ECDHE_RSA_WITH_RC4_128_SHA:TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA:TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA:TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA:TLS_DHE_RSA_WITH_AES_128_CBC_SHA:HIGH:!aNULL:!MD5;
+  ssl_session_cache shared:SSL:10m;
+<% end %>
 }


### PR DESCRIPTION
This patch writes /etc/default/elasticsearch, using the one shipped with the deb as a base.  It uses the configured value for `node.elasticsearch[:allocated_memory]`.  Theoretically this could be extended to support other configurable attributes, and/or support the RPM version as well.