### PR TITLE
Introduce user provider and resource

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,11 +6,9 @@ group :lint do
 end
 
 group :unit do
-  gem 'rspec'
-  gem 'chef', '>= 11.16'
+  gem 'berkshelf', '~> 3'
   gem 'chefspec', '>= 4.2'
   gem 'chef-sugar'
-  gem 'berkshelf', '~> 3'
 end
 
 group :kitchen_common do


### PR DESCRIPTION
- Fixes #269, adds an `elasticsearch_user` resource with provider that creates a user, group, and removes the automatic homedir

- Pins chef to 11.16.4 since chef 12 and many libraries like poise aren't compatible yet

- Adds an `elasticsearch_test` kitchenCI suite that tests edge cases, so the default test suite can test the expected way people use the cookbook

- Tweak rubocop rules to avoid style complaints about methods that are too complex (controversial rule) and compact class styles (also controversial at the moment)

- Updated `README.md` with an example of how to use the `elasticsearch_user` resource