### PR TITLE
use suggests instead of recommends for Berkshelf users

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -9,10 +9,10 @@ version          "0.3.13"
 
 depends 'ark', '>= 0.2.4'
 
-recommends 'build-essential'
-recommends 'xml'
-recommends 'java'
-recommends 'monit'
+suggests 'build-essential'
+suggests 'xml'
+suggests 'java'
+suggests 'monit'
 
 provides 'elasticsearch'
 provides 'elasticsearch::data'


### PR DESCRIPTION
PR for https://github.com/elasticsearch/cookbook-elasticsearch/issues/275

This is for Berkshelf users who will get errors when trying to upload wrapper cookbooks, similar to this one:

Dependency 'java' was not found. Please make sure it is in your Berksfile, and then run `berks install` to download and install the missing dependencies.

suggests, like recommends has no side effect and will not be added to the dependencies in Berkshelf: https://github.com/berkshelf/berkshelf/issues/895