### PR TITLE
add ssl proxy attributes

### DIFF
--- a/attributes/proxy.rb
+++ b/attributes/proxy.rb
@@ -33,4 +33,6 @@ default.elasticsearch[:nginx][:allow_status] = false
 # Other Nginx proxy settings
 #
 default.elasticsearch[:nginx][:client_max_body_size] = "50M"
-default.elasticsearch[:nginx][:location] = "/"
+default.elasticsearch[:nginx][:location]             = "/"
+default.elasticsearch[:nginx][:ssl][:cert_file]      = nil
+default.elasticsearch[:nginx][:ssl][:key_file]       = nil


### PR DESCRIPTION
Fixes https://github.com/elasticsearch/cookbook-elasticsearch/issues/281 by specifying default attributes set to nil.