### PR TITLE
Suppress increase limits log when not updating

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -117,13 +117,18 @@ bash "enable user limits" do
   not_if { ::File.read("/etc/pam.d/su").match(/^session    required   pam_limits\.so/) }
 end
 
-log "increase limits for the elasticsearch user"
-
 file "/etc/security/limits.d/10-elasticsearch.conf" do
   content <<-END.gsub(/^    /, '')
     #{node.elasticsearch.fetch(:user, "elasticsearch")}     -    nofile    #{node.elasticsearch[:limits][:nofile]}
     #{node.elasticsearch.fetch(:user, "elasticsearch")}     -    memlock   #{node.elasticsearch[:limits][:memlock]}
   END
+
+  notifies :write, 'log[increase limits]', :immediately
+end
+
+log "increase limits" do
+  message "increased limits for the elasticsearch user"
+  action :nothing
 end
 
 # Create file with ES environment variables


### PR DESCRIPTION
The log is now only written if the file resource is updated.