### PR TITLE
more http setting fields, such as CORS support

### DIFF
--- a/templates/default/elasticsearch.yml.erb
+++ b/templates/default/elasticsearch.yml.erb
@@ -61,7 +61,20 @@
 <%= print_value 'transport.tcp.compress' -%>
 <%= print_value 'http.host' -%>
 <%= print_value 'http.port' -%>
+<%= print_value 'http.bind_port' -%>
+<%= print_value 'http.publish_port' -%>
 <%= print_value 'http.max_content_length' -%>
+<%= print_value 'http.max_initial_line_length' -%>
+<%= print_value 'http.compression' -%>
+<%= print_value 'http.compression_level' -%>
+<%= print_value 'http.cors.enabled' -%>
+<%= print_value 'http.cors.allow-origin' -%>
+<%= print_value 'http.cors.max-age' -%>
+<%= print_value 'http.cors.allow-methods' -%>
+<%= print_value 'http.cors.allow-headers' -%>
+<%= print_value 'http.cors.allow-credentials' -%>
+<%= print_value 'http.pipelining' -%>
+<%= print_value 'http.pipelining.max_events' -%>
 <%= print_value 'http.enabled' -%>
 
 ################################### Gateway ###################################


### PR DESCRIPTION
supports http.cors settings introduced in ElasticSearch 1.4
http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/modules-http.html