### PR TITLE
Update Elasticsearch start command

### DIFF
--- a/templates/default/elasticsearch.monitrc.conf.erb
+++ b/templates/default/elasticsearch.monitrc.conf.erb
@@ -3,7 +3,7 @@
 # ------------------------------------------
 
 check process elasticsearch with pidfile <%= node.elasticsearch[:pid_file] %>
-  start program = "/etc/init.d/elasticsearch restart" with timeout 60 seconds
+  start program = "/etc/init.d/elasticsearch start" with timeout 60 seconds
   stop program  = "/etc/init.d/elasticsearch stop"
   if cpu > 90% for 15 cycles then alert
   if totalmem > 90% for 15 cycles then alert


### PR DESCRIPTION
Restart will fail to remove the PID file 

Removing PID file...                                                   
rm: cannot remove `/usr/local/var/run/search1.pid': Permission denied